### PR TITLE
add ReCaLL attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ We include and implement the following attacks, as described in our paper.
 - [Min-K% Prob](https://swj0419.github.io/detect-pretrain.github.io/) (`min_k`). Uses k% of tokens with minimum likelihood for score computation.
 - [Min-K%++](https://zjysteven.github.io/mink-plus-plus/) (`min_k++`). Uses k% of tokens with minimum *normalized* likelihood for score computation.
 - [Gradient Norm](https://arxiv.org/abs/2402.17012) (`gradnorm`). Uses gradient norm of the target datapoint as score.
+- [ReCaLL](https://royxie.com/recall-project-page/)(`recall`). Operates by comparing the unconditional and conditional log-likelihoods. 
 
 ## Adding your own dataset
 

--- a/configs/new_mi.json
+++ b/configs/new_mi.json
@@ -8,25 +8,19 @@
     "max_tokens": 512,
     "max_data": 100000,
     "output_name": "unified_mia",
-    "specific_source": "Github_ngram_13_<0.8_truncated",
+    "specific_source": "Github",
     "n_samples": 1000,
-    "blackbox_attacks": ["loss", "min_k", "zlib"],
+    "blackbox_attacks": ["loss", "ref", "min_k", "zlib"],
+    "ref_config": {
+        "models": [
+            "stabilityai/stablelm-base-alpha-3b-v2"
+        ]
+    },
     "env_config": {
         "results": "results_new",
         "device_map": "balanced_low_0"
     },
-    "neighborhood_config": {
-        "model": "bert",
-        "n_perturbation_list": [
-            25
-        ],
-        "pct_words_masked": 0.3,
-        "span_length": 2,
-        "dump_cache": false,
-        "load_from_cache": true,
-        "neighbor_strategy": "random"
-    },
     "dump_cache": false,
-    "load_from_cache": false,
-    "load_from_hf": true
+    "load_from_cache": true,
+    "load_from_hf": false
 }

--- a/configs/recall.json
+++ b/configs/recall.json
@@ -10,7 +10,6 @@
     "output_name": "unified_mia",
     "specific_source": "Github_ngram_13_<0.8_truncated",
     "n_samples": 1000,
-    "recall_num_shots": 1,
     "blackbox_attacks": ["loss", "ref", "zlib", "min_k", "min_k++", "recall"],
     "env_config": {
         "results": "results_new",
@@ -21,6 +20,9 @@
         "models": [
             "EleutherAI/pythia-160m"
         ]
+    },
+    "recall_config":{
+        "num_shots": 1
     },
     "neighborhood_config": {
         "model": "bert",

--- a/configs/recall.json
+++ b/configs/recall.json
@@ -1,5 +1,5 @@
 {
-    "experiment_name": "edited_members_exp",
+    "experiment_name": "recall",
     "base_model": "EleutherAI/pythia-1.4b",
     "dataset_member": "the_pile",
     "dataset_nonmember": "the_pile",

--- a/configs/recall.json
+++ b/configs/recall.json
@@ -10,7 +10,8 @@
     "output_name": "unified_mia",
     "specific_source": "Github_ngram_13_<0.8_truncated",
     "n_samples": 1000,
-    "blackbox_attacks": ["loss", "min_k", "zlib", "recall"],
+    "recall_num_shots": 1,
+    "blackbox_attacks": ["recall"],
     "env_config": {
         "results": "results_new",
         "device_map": "balanced_low_0"

--- a/configs/recall.json
+++ b/configs/recall.json
@@ -10,7 +10,7 @@
     "output_name": "unified_mia",
     "specific_source": "Github_ngram_13_<0.8_truncated",
     "n_samples": 1000,
-    "blackbox_attacks": ["loss", "min_k", "zlib"],
+    "blackbox_attacks": ["loss", "min_k", "zlib", "recall"],
     "env_config": {
         "results": "results_new",
         "device_map": "balanced_low_0"

--- a/configs/recall.json
+++ b/configs/recall.json
@@ -1,6 +1,6 @@
 {
     "experiment_name": "edited_members_exp",
-    "base_model": "EleutherAI/gpt-neo-125m",
+    "base_model": "EleutherAI/pythia-1.4b",
     "dataset_member": "the_pile",
     "dataset_nonmember": "the_pile",
     "min_words": 100,
@@ -11,10 +11,16 @@
     "specific_source": "Github_ngram_13_<0.8_truncated",
     "n_samples": 1000,
     "recall_num_shots": 1,
-    "blackbox_attacks": ["recall"],
+    "blackbox_attacks": ["loss", "ref", "zlib", "min_k", "min_k++", "recall"],
     "env_config": {
         "results": "results_new",
-        "device_map": "balanced_low_0"
+        "device": "cuda:0",
+        "device_aux": "cuda:0"
+    },
+    "ref_config": {
+        "models": [
+            "EleutherAI/pythia-160m"
+        ]
     },
     "neighborhood_config": {
         "model": "bert",

--- a/mimir/attacks/all_attacks.py
+++ b/mimir/attacks/all_attacks.py
@@ -15,6 +15,7 @@ class AllAttacks(str, Enum):
     MIN_K_PLUS_PLUS = "min_k++" # Done
     NEIGHBOR = "ne" # Done
     GRADNORM = "gradnorm" # Done
+    RECALL = "recall"
     # QUANTILE = "quantile" # Uncomment when tested implementation is available
 
 

--- a/mimir/attacks/recall.py
+++ b/mimir/attacks/recall.py
@@ -13,6 +13,44 @@ class ReCaLLAttack(Attack):
         super().__init__(config, target_model, ref_model = None)
 
     @torch.no_grad()
-    def _attack(self, document, probs, tokens = None, **kwargs):
-        # TODO implement ReCaLL Attack
-        raise NotImplementedError("Need to do")
+    def _attack(self, document, probs, tokens = None, **kwargs):        
+        nonmember_prefix = kwargs.get("nonmember_prefix", None)
+        assert nonmember_prefix, "nonmember_prefix should not be None or empty"
+
+        lls = self.target_model.get_ll(document, probs = probs, tokens = tokens)
+        ll_nonmember = self.get_conditional_ll(nonmember_prefix = nonmember_prefix, text = document,
+                                                model = self.target_model, tokenizer=self.target_model.tokenizer, tokens = tokens)
+        recall = ll_nonmember / lls
+
+        return recall
+    
+    def get_conditional_ll(self, nonmember_prefix, text, model, tokenizer, tokens = None):
+        assert nonmember_prefix, "nonmember_prefix should not be None or empty"
+        
+        input_encodings = tokenizer(text = nonmember_prefix, return_tensors="pt")
+        if tokens is None:
+            target_encodings = tokenizer(text = text, return_tensors="pt")
+        else:
+            target_encodings = tokens
+
+        max_length = model.max_length
+        input_ids = input_encodings.input_ids.to(model.device)
+        target_ids = target_encodings.input_ids.to(model.device)
+        
+        total_length = input_ids.size(1) + target_ids.size(1)
+        
+        if total_length > max_length:
+            excess_length = total_length - max_length
+            target_ids = target_ids[:, :-excess_length] 
+        concat_ids = torch.cat((input_ids, target_ids), dim=1)
+        labels = concat_ids.clone()
+        labels[:, :input_ids.size(1)] = -100
+
+        with torch.no_grad():
+            outputs = model.model(concat_ids, labels=labels)
+        
+        loss, logits = outputs[:2]
+        ll = -loss.item()
+        return ll
+    
+

--- a/mimir/attacks/recall.py
+++ b/mimir/attacks/recall.py
@@ -81,19 +81,17 @@ class ReCaLLAttack(Attack):
         text_ids = target_encodings.input_ids.to(model.device)
 
         max_length = model.max_length
-        total_length = prefix_ids.size(1) + text_ids.size(1)
 
         if prefix_ids.size(1) >= max_length:
             raise ValueError("Prefix length exceeds or equals the model's maximum context window.")
-        stride = model.stride
 
         labels = torch.cat((prefix_ids, text_ids), dim=1)
 
         total_loss = 0
         with torch.no_grad():
-            for i in range(0, labels.size(1), stride):
-                begin_loc = max(i + stride - max_length, 0)
-                end_loc = min(i + stride, labels.size(1))
+            for i in range(0, labels.size(1), max_length):
+                begin_loc = max(i - max_length, 0)
+                end_loc = min(i, labels.size(1))
                 trg_len = end_loc - i
                 input_ids = labels[:, begin_loc:end_loc].to(model.device)
                 target_ids = input_ids.clone()

--- a/mimir/attacks/recall.py
+++ b/mimir/attacks/recall.py
@@ -9,6 +9,9 @@ from mimir.config import ExperimentConfig
 
 class ReCaLLAttack(Attack):
 
+    #** Note: this is a suboptimal implementation of the ReCaLL attack due to necessary changes made to integrate it alongside the other attacks
+    #** for a better performing version, please refer to: https://github.com/ruoyuxie/recall 
+    
     def __init__(self, config: ExperimentConfig, target_model: Model):
         super().__init__(config, target_model, ref_model = None)
         self.prefix = None
@@ -22,6 +25,8 @@ class ReCaLLAttack(Attack):
         avg_length = recall_dict.get("avg_length")
 
         assert nonmember_prefix, "nonmember_prefix should not be None or empty"
+        assert num_shots, "num_shots should not be None or empty"
+        assert avg_length, "avg_length should not be None or empty"
 
         lls = self.target_model.get_ll(document, probs = probs, tokens = tokens)
         ll_nonmember = self.get_conditional_ll(nonmember_prefix = nonmember_prefix, text = document,

--- a/mimir/attacks/recall.py
+++ b/mimir/attacks/recall.py
@@ -1,0 +1,18 @@
+"""
+    ReCaLL Attack: https://github.com/ruoyuxie/recall/
+"""
+import torch 
+import numpy as np
+from mimir.attacks.all_attacks import Attack
+from mimir.models import Model
+from mimir.config import ExperimentConfig
+
+class ReCaLLAttack(Attack):
+
+    def __init__(self, config: ExperimentConfig, target_model: Model):
+        super().__init__(config, target_model, ref_model = None)
+
+    @torch.no_grad()
+    def _attack(self, document, probs, tokens = None, **kwargs):
+        # TODO implement ReCaLL Attack
+        raise NotImplementedError("Need to do")

--- a/mimir/attacks/recall.py
+++ b/mimir/attacks/recall.py
@@ -14,43 +14,103 @@ class ReCaLLAttack(Attack):
 
     @torch.no_grad()
     def _attack(self, document, probs, tokens = None, **kwargs):        
-        nonmember_prefix = kwargs.get("nonmember_prefix", None)
+        recall_dict: dict = kwargs.get("recall_dict", None)
+
+        nonmember_prefix = recall_dict.get("prefix")
+        num_shots = recall_dict.get("num_shots")
+        avg_length = recall_dict.get("avg_length")
+
         assert nonmember_prefix, "nonmember_prefix should not be None or empty"
 
         lls = self.target_model.get_ll(document, probs = probs, tokens = tokens)
         ll_nonmember = self.get_conditional_ll(nonmember_prefix = nonmember_prefix, text = document,
-                                                model = self.target_model, tokenizer=self.target_model.tokenizer, tokens = tokens)
+                                                num_shots = num_shots, avg_length = avg_length,
+                                                  tokens = tokens)
         recall = ll_nonmember / lls
 
         return recall
     
-    def get_conditional_ll(self, nonmember_prefix, text, model, tokenizer, tokens = None):
+    def process_prefix(self, prefix, avg_length, total_shots):
+        model = self.target_model
+        tokenizer = self.target_model.tokenizer
+
+        max_length = model.max_length
+        token_counts = [len(tokenizer.encode(shot)) for shot in prefix]
+
+        target_token_count = avg_length
+        total_tokens = sum(token_counts) + target_token_count
+        if total_tokens<=max_length:
+            return prefix
+        # Determine the maximum number of shots that can fit within the max_length
+        max_shots = 0
+        cumulative_tokens = target_token_count
+        for count in token_counts:
+            if cumulative_tokens + count <= max_length:
+                max_shots += 1
+                cumulative_tokens += count
+            else:
+                break
+        # Truncate the prefix to include only the maximum number of shots
+        truncated_prefix = prefix[-max_shots:]
+        print(f"""Too many shots used. Initial ReCaLL number of shots was {total_shots}.
+                 Maximum number of shots is {max_shots}. Defaulting to maximum number of shots.""")
+        return truncated_prefix
+    
+    def get_conditional_ll(self, nonmember_prefix, text, num_shots, avg_length, tokens=None):
         assert nonmember_prefix, "nonmember_prefix should not be None or empty"
-        
-        input_encodings = tokenizer(text = nonmember_prefix, return_tensors="pt")
+
+        model = self.target_model
+        tokenizer = self.target_model.tokenizer
+
         if tokens is None:
-            target_encodings = tokenizer(text = text, return_tensors="pt")
+            target_encodings = tokenizer(text=text, return_tensors="pt")
         else:
             target_encodings = tokens
 
-        max_length = model.max_length
-        input_ids = input_encodings.input_ids.to(model.device)
-        target_ids = target_encodings.input_ids.to(model.device)
-        
-        total_length = input_ids.size(1) + target_ids.size(1)
-        
-        if total_length > max_length:
-            excess_length = total_length - max_length
-            target_ids = target_ids[:, :-excess_length] 
-        concat_ids = torch.cat((input_ids, target_ids), dim=1)
-        labels = concat_ids.clone()
-        labels[:, :input_ids.size(1)] = -100
+        processed_prefix = self.process_prefix(nonmember_prefix, avg_length, total_shots=num_shots)
+        input_encodings = tokenizer(text=processed_prefix, return_tensors="pt")
 
+        prefix_ids = input_encodings.input_ids.to(model.device)
+        text_ids = target_encodings.input_ids.to(model.device)
+
+        max_length = model.max_length
+        total_length = prefix_ids.size(1) + text_ids.size(1)
+
+        if prefix_ids.size(1) >= max_length:
+            raise ValueError("Prefix length exceeds or equals the model's maximum context window.")
+
+        log_likelihoods = []
+        stride = model.stride
+
+        labels = torch.cat((prefix_ids, text_ids), dim=1)
         with torch.no_grad():
-            outputs = model.model(concat_ids, labels=labels)
-        
-        loss, logits = outputs[:2]
-        ll = -loss.item()
-        return ll
+            for i in range(0, labels.size(1), stride):
+
+                begin_loc = max(i + stride - max_length, 0)
+                end_loc = min(i + stride, labels.size(1))
+                trg_len = end_loc - i  # This may be different from stride on the last loop
+
+                # Extract the input_ids for the current window
+                input_ids = labels[:, begin_loc:end_loc].to(model.device)
+                
+                # Clone input_ids to create target_ids, masking out the prefix and the initial part of the text
+                target_ids = input_ids.clone()
+                
+                # Masking: prefix part + initial part of the text in the sliding window
+                if begin_loc < prefix_ids.size(1):
+                    prefix_mask_length = prefix_ids.size(1) - begin_loc
+                    target_ids[:, :prefix_mask_length] = -100
+                
+                # Mask the initial part of the text according to trg_len
+                target_ids[:, :-trg_len] = -100
+
+                outputs = model.model(input_ids, labels=target_ids)
+                loss = outputs.loss
+
+                log_likelihoods.append(-loss.item())
+
+        total_log_likelihood = sum(log_likelihoods)
+        return total_log_likelihood
+
     
 

--- a/mimir/attacks/utils.py
+++ b/mimir/attacks/utils.py
@@ -7,7 +7,7 @@ from mimir.attacks.min_k import MinKProbAttack
 from mimir.attacks.min_k_plus_plus import MinKPlusPlusAttack
 from mimir.attacks.neighborhood import NeighborhoodAttack
 from mimir.attacks.gradnorm import GradNormAttack
-from mimir.attacks.recall import ReCallAttack
+from mimir.attacks.recall import ReCaLLAttack
 
 
 # TODO Use decorators to link attack implementations with enum above

--- a/mimir/attacks/utils.py
+++ b/mimir/attacks/utils.py
@@ -7,6 +7,7 @@ from mimir.attacks.min_k import MinKProbAttack
 from mimir.attacks.min_k_plus_plus import MinKPlusPlusAttack
 from mimir.attacks.neighborhood import NeighborhoodAttack
 from mimir.attacks.gradnorm import GradNormAttack
+from mimir.attacks.recall import ReCallAttack
 
 
 # TODO Use decorators to link attack implementations with enum above
@@ -19,6 +20,7 @@ def get_attacker(attack: str):
         AllAttacks.MIN_K_PLUS_PLUS: MinKPlusPlusAttack,
         AllAttacks.NEIGHBOR: NeighborhoodAttack,
         AllAttacks.GRADNORM: GradNormAttack,
+        AllAttacks.RECALL: ReCaLLAttack
     }
     attack_cls = mapping.get(attack, None)
     if attack_cls is None:

--- a/mimir/config.py
+++ b/mimir/config.py
@@ -59,6 +59,13 @@ class NeighborhoodConfig(Serializable):
         if self.dump_cache and self.load_from_cache:
             raise ValueError("Cannot dump and load cache at the same time")
 
+@dataclass
+class ReCaLLConfig(Serializable):
+    """
+    Config for ReCaLL attack
+    """
+    num_shots: Optional[int] = 1
+    """Number of shots for ReCaLL Attacks"""
 
 @dataclass
 class EnvironmentConfig(Serializable):
@@ -174,8 +181,6 @@ class ExperimentConfig(Serializable):
     """Chunk size"""
     scoring_model_name: Optional[str] = None
     """Scoring model (if different from base model)"""
-    recall_num_shots: Optional[int] = 1
-    """Number of shots for ReCaLL Attacks"""
     top_k: Optional[int] = 40
     """Consider only top-k tokens"""
     do_top_k: Optional[bool] = False
@@ -196,6 +201,8 @@ class ExperimentConfig(Serializable):
     """Random seed"""
     ref_config: Optional[ReferenceConfig] = None
     """Reference model config"""
+    recall_config: Optional[ReCaLLConfig] = None
+    """ReCaLL attack config"""
     neighborhood_config: Optional[NeighborhoodConfig] = None
     """Neighborhood attack config"""
     env_config: Optional[EnvironmentConfig] = None

--- a/mimir/config.py
+++ b/mimir/config.py
@@ -174,6 +174,8 @@ class ExperimentConfig(Serializable):
     """Chunk size"""
     scoring_model_name: Optional[str] = None
     """Scoring model (if different from base model)"""
+    recall_num_shots: Optional[int] = 1
+    """Number of shots for ReCaLL Attacks"""
     top_k: Optional[int] = 40
     """Consider only top-k tokens"""
     do_top_k: Optional[bool] = False

--- a/run.py
+++ b/run.py
@@ -105,7 +105,10 @@ def get_mia_scores(
     if AllAttacks.RECALL in attackers_dict.keys():
         if nonmember_prefix is None:
             raise ValueError("Must include a prefix for ReCaLL attack")
-        
+        num_shots = config.recall_num_shots
+        avg_length = int(np.mean([len(target_model.tokenizer.encode(ex)) for ex in data["records"]]))
+        recall_dict = {"prefix":nonmember_prefix, "num_shots":num_shots, "avg_length":avg_length}
+
     # For each batch of data
     # TODO: Batch-size isn't really "batching" data - change later
     for batch in tqdm(range(math.ceil(n_samples / batch_size)), desc=f"Computing criterion"):
@@ -166,7 +169,7 @@ def get_mia_scores(
                             ),
                             loss=loss,
                             all_probs=s_all_probs,
-                            nonmember_prefix = nonmember_prefix
+                            recall_dict = recall_dict
                         )
                         sample_information[attack].append(score)
                         


### PR DESCRIPTION
Hi @iamgroot42,

In this pull request we introduce ReCaLL into the unified benchmark as defined [here](https://royxie.com/recall-project-page/)

### Overview
ReCaLL is a novel membership inference attack (MIA) method designed to detect pretraining data in large language models (LLMs). It leverages the conditional language modeling capabilities of LLMs to identify whether a given piece of text was part of the model's training data

### Files Changed
`readme.md`: added ReCaLL to list of attacks.
`configs/recall.json`: added config file to run ReCaLL on its own.
`mimir/attacks/all_attacks.py`: added ReCaLL to list of attacks.
`mimir/attacks/recall.py`:  implemented ReCaLL attack.
`mimir/attacks/utils.py`: added ReCaLL to attacker mapping .
`mimir/config.py`: added support for recall_num_shots, to allow ReCaLL to be run with more than one shot. 
`run.py`: added necessary support to allow ReCaLL to run as well as verify it is being run correctly

### Implementation Details

- The ReCaLL attack is implemented in mimir/attacks/recall.py, following the algorithm described in the original [paper](https://arxiv.org/abs/2406.15968).
- We've added support for multiple shots in the config, enabling varied experimentation with this parameter.
- The attack can be run independently using the configs/recall.json configuration file.

Please review the changes and let me know if any modifications or additional information is needed. 
Thanks so much! 🙌

